### PR TITLE
Fix platform/partner/application client request helper

### DIFF
--- a/sdk/application/ApplicationClient.js
+++ b/sdk/application/ApplicationClient.js
@@ -17,7 +17,7 @@ const Webhook = require("./Webhook/WebhookApplicationClient");
 const { FDKClientValidationError } = require("../common/FDKError");
 const { Logger } = require("../common/Logger");
 const { convertStringToBase64 } = require("../common/utils");
-const { execute } = require("./ApplicationAPIClient");
+const ApplicationAPIClient = require("./ApplicationAPIClient");
 
 /**
  * Represents the client for the application.
@@ -111,9 +111,17 @@ class ApplicationClient {
     headers,
     responseHeaders = false,
   }) {
-    return await execute(this.config, method, url, query, body, headers, {
-      responseHeaders,
-    });
+    return await ApplicationAPIClient.execute(
+      this.config,
+      method,
+      url,
+      query,
+      body,
+      headers,
+      {
+        responseHeaders,
+      }
+    );
   }
 }
 

--- a/sdk/partner/PartnerClient.js
+++ b/sdk/partner/PartnerClient.js
@@ -9,7 +9,7 @@ const Theme = require("./Theme/ThemePartnerClient");
 const Webhook = require("./Webhook/WebhookPartnerClient");
 
 const { FDKClientValidationError } = require("../common/FDKError");
-const { execute } = require("./PartnerAPIClient");
+const PartnerAPIClient = require("./PartnerAPIClient");
 
 /**
  * Represents the client for the partner APIs.
@@ -54,9 +54,17 @@ class PartnerClient {
     headers,
     responseHeaders = false,
   }) {
-    return await execute(this.config, method, url, query, body, headers, {
-      responseHeaders,
-    });
+    return await PartnerAPIClient.execute(
+      this.config,
+      method,
+      url,
+      query,
+      body,
+      headers,
+      {
+        responseHeaders,
+      }
+    );
   }
 }
 

--- a/sdk/platform/PlatformClient.js
+++ b/sdk/platform/PlatformClient.js
@@ -34,7 +34,7 @@ const Webhook = require("./Webhook/WebhookPlatformClient");
 
 const PlatformApplicationClient = require("./PlatformApplicationClient");
 const { FDKClientValidationError } = require("../common/FDKError");
-const { execute } = require("./PlatformAPIClient");
+const PlatformAPIClient = require("./PlatformAPIClient");
 
 /**
  * Represents the client for the platform.
@@ -125,9 +125,17 @@ class PlatformClient {
     headers,
     responseHeaders = false,
   }) {
-    return await execute(this.config, method, url, query, body, headers, {
-      responseHeaders,
-    });
+    return await PlatformAPIClient.execute(
+      this.config,
+      method,
+      url,
+      query,
+      body,
+      headers,
+      {
+        responseHeaders,
+      }
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- fix require of PlatformAPIClient, PartnerAPIClient and ApplicationAPIClient
- call execute via class references

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6846ec7965bc832f85b0538929d13787